### PR TITLE
Pass python version to python-pypi-publish workflow

### DIFF
--- a/.github/workflows/compound-python.yml
+++ b/.github/workflows/compound-python.yml
@@ -160,6 +160,7 @@ jobs:
     uses: th2-net/.github/.github/workflows/python-pypi-publish.yml@main
     with:
       version: ${{ needs.build-custom-version.outputs.release-version }}
+      python-version: ${{ inputs.pythonVersion }}
     secrets:
       pypi-password: ${{ secrets.pypi-password }}
   


### PR DESCRIPTION
Pass provided python version to the publication workflow