### PR TITLE
Adapt workflows to be triggered by dependabot

### DIFF
--- a/.github/workflows/compaund-java-docker-push.yml
+++ b/.github/workflows/compaund-java-docker-push.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
+        # dependabot does not have required secrets
+        if: github.actor != 'dependabot[bot]'
         with:
           registry: ghcr.io
           username: ${{ inputs.docker-username }}
@@ -71,7 +73,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.dockerContext }}
-          push: true
+          # the images build for dependabot PRs will not be pushed into repository
+          push: ${{ github.actor != 'dependabot[bot]' }}
           tags: ghcr.io/${{ github.repository }}:${{ inputs.version }}
           labels: com.exactpro.th2.${{ steps.meta.outputs.REPOSITORY_NAME }}=${{ inputs.versionNumber }}
           provenance: false

--- a/.github/workflows/compaund-java-sonatype-push.yml
+++ b/.github/workflows/compaund-java-sonatype-push.yml
@@ -62,7 +62,14 @@ jobs:
           gradle-version: wrapper
       - name: Release Build with Gradle
         if: ${{ inputs.closeAndRelease }}
-        run: ./gradlew -p ${{ inputs.projectPath }} --info clean build -Prelease_version=${{ inputs.version }} publish closeAndReleaseSonatypeStagingRepository
+        run: >
+          ./gradlew
+          -p ${{ inputs.projectPath }}
+          --info
+          clean
+          build
+          -Prelease_version=${{ inputs.version }}
+          ${{ github.actor == 'dependabot[bot]' && '' || 'publish closeAndReleaseSonatypeStagingRepository' }}
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatypeUsername }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatypePassword }}
@@ -70,7 +77,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.sonatypeSigningPassword }}
       - name: Dev Build with Gradle
         if: ${{ !inputs.closeAndRelease }}
-        run: ./gradlew -p ${{ inputs.projectPath }} --info clean build -Prelease_version=${{ format('{0}-SNAPSHOT', inputs.version) }} publish
+        run: >
+          ./gradlew
+          -p ${{ inputs.projectPath }}
+          --info
+          clean
+          build
+          -Prelease_version=${{ format('{0}-SNAPSHOT', inputs.version) }}
+          ${{ github.actor == 'dependabot[bot]' && '' || 'publish' }}
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatypeUsername }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatypePassword }}

--- a/.github/workflows/compaund-java-sonatype-push.yml
+++ b/.github/workflows/compaund-java-sonatype-push.yml
@@ -69,7 +69,7 @@ jobs:
           clean
           build
           -Prelease_version=${{ inputs.version }}
-          ${{ github.actor == 'dependabot[bot]' && '' || 'publish closeAndReleaseSonatypeStagingRepository' }}
+          ${{ github.actor != 'dependabot[bot]' && 'publish closeAndReleaseSonatypeStagingRepository' || '' }}
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatypeUsername }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatypePassword }}
@@ -84,7 +84,7 @@ jobs:
           clean
           build
           -Prelease_version=${{ format('{0}-SNAPSHOT', inputs.version) }}
-          ${{ github.actor == 'dependabot[bot]' && '' || 'publish' }}
+          ${{ github.actor != 'dependabot[bot]' && 'publish' || '' }}
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatypeUsername }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatypePassword }}

--- a/.github/workflows/trivy-scan-github.yml
+++ b/.github/workflows/trivy-scan-github.yml
@@ -45,6 +45,7 @@ jobs:
           vuln-type: ${{ inputs.target }}
           timeout: 20m0s
       - name: Upload Trivy scan results to GitHub Security tab
+        if: github.actor != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Currently, the dev build workflows (for java) cannot be executed for dependabot PRs because they require secrets that are not provided for depenabot.
There are two options:

- if we want to publish artifacts from Dependabot PRs we can add secrets for Dependabot (Settings > Secrets and Variables> Dependabot). In this case, we don't need to modify the workflow
- if we don't want to publish artifacts and just want to have CI executed to see if changes are compatible we can skip workflow parts that require secrets (docker login and publication, sonatype publication)

The last option is done in this PR. @Nikita-Smirnov-Exactpro could you please take a look? After that, we can stop ignoring dependabot branches in the repositories and execute CI for them