### PR TITLE
Skip empty licenses when java report is analyzed

### DIFF
--- a/license-compliance/check_licenses.sh
+++ b/license-compliance/check_licenses.sh
@@ -227,11 +227,14 @@ for main in `cat $temp_res | tr ' ' ';'`
 					# trim ; (former space) from start and end of the item
 					item=${item#;}
 					item=${item%;}
-					if [[ $lic == "" ]]
+					if [[ $item != '""' ]]
 					then
+						if [[ $lic == "" ]]
+						then
 						lic=$item
-					else
+						else
 						lic=$lic" | "$item
+						fi
 					fi
 				fi
 			done


### PR DESCRIPTION
This change is required for the case
project-licenses-for-check-license-task.json
```json
{
    "moduleName": "com.github.ajalt.mordant:mordant",
    "moduleVersion": "2.0.0",
    "moduleUrls": [
        "https://github.com/ajalt/mordant/"
    ],
    "moduleLicenses": [
        {
            "moduleLicense": "",
            "moduleLicenseUrl": ""
        },
        {
            "moduleLicense": "Apache-2.0",
            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.txt"
        }
    ]
}
```
script error:
```
--------------------------------------
2025-02-27 18:11:35: Line = "com.github.ajalt.mordant:mordant","2.0.0"," | Apache-2.0 | "
2025-02-27 18:11:35: Result = ***FAILED***
--------------------------------------
```

https://github.com/th2-net/th2-cradle-data-generator/actions/runs/13565991924/job/37919141558