### PR TITLE
Use ubuntu-latest by default for every workflow

### DIFF
--- a/.github/workflows/compaund-git-tag-push.yml
+++ b/.github/workflows/compaund-git-tag-push.yml
@@ -6,7 +6,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       tagName:
         required: true
         type: string

--- a/.github/workflows/compaund-java-docker-push.yml
+++ b/.github/workflows/compaund-java-docker-push.yml
@@ -9,7 +9,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       version:
         required: true
         type: string

--- a/.github/workflows/compaund-java-multi-project-build.yml
+++ b/.github/workflows/compaund-java-multi-project-build.yml
@@ -6,7 +6,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       release:
         required: false
         type: boolean

--- a/.github/workflows/compaund-java-sonatype-push.yml
+++ b/.github/workflows/compaund-java-sonatype-push.yml
@@ -6,7 +6,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       closeAndRelease:
         required: true
         type: boolean

--- a/.github/workflows/compaund-python-grpc-pypi-publication.yml
+++ b/.github/workflows/compaund-python-grpc-pypi-publication.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish Python distributions to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set version for current build in package_info.json

--- a/.github/workflows/compaund-python-grpc-pypi-publication.yml
+++ b/.github/workflows/compaund-python-grpc-pypi-publication.yml
@@ -24,7 +24,7 @@ on:
       python-version:
         required: false
         type: string
-        default: '3.7'
+        default: '3.8'
     secrets:
       pypi_password:
         required: true

--- a/.github/workflows/compound-prebuild-java-dev-workflow.yml
+++ b/.github/workflows/compound-prebuild-java-dev-workflow.yml
@@ -7,7 +7,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       project-path:
         required: false
         type: string

--- a/.github/workflows/compound-prebuild-java-workflow.yml
+++ b/.github/workflows/compound-prebuild-java-workflow.yml
@@ -7,7 +7,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       devRelease:
         required: false
         type: boolean

--- a/.github/workflows/compound-python-matrix-style-check.yml
+++ b/.github/workflows/compound-python-matrix-style-check.yml
@@ -7,7 +7,7 @@ on:
       matrix-python-versions:
         required: false
         type: string
-        default: "['3.7', '3.8', '3.9']"
+        default: "['3.8', '3.9', '3.10']"
         description: 'list of python versions in JSON format'
       runsOn:
         required: false

--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release_ver.outputs.value }}
     steps:

--- a/.github/workflows/japi-compliance-checker.yml
+++ b/.github/workflows/japi-compliance-checker.yml
@@ -6,7 +6,7 @@ on:
       runsOn:
         required: false
         type: string
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-latest'
       javaVersion:
         required: false
         type: string

--- a/.github/workflows/trivy-scan-github.yml
+++ b/.github/workflows/trivy-scan-github.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   trivy-scan-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Show scanning target
         run: echo ${{ inputs.image-path }}

--- a/.github/workflows/trivy-scan-lockfile-github.yml
+++ b/.github/workflows/trivy-scan-lockfile-github.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   trivy-scan-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/trivy-scan-table.yml
+++ b/.github/workflows/trivy-scan-table.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   trivy-scan-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Show scanning target
         run: echo ${{ inputs.image-path }}

--- a/workflow-templates/ci-unwelcome-words.yml
+++ b/workflow-templates/ci-unwelcome-words.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:

--- a/workflow-templates/dev-docker-publish.yml
+++ b/workflow-templates/dev-docker-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 # Prepare custom build version

--- a/workflow-templates/dev-grpc-services-pypi-publish.yml
+++ b/workflow-templates/dev-grpc-services-pypi-publish.yml
@@ -10,14 +10,14 @@ on:
 jobs:
   build-n-publish:
     name: Dev build and Python distributions to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 # Prepare custom build version
     - name: Get package version
       id: pack_ver
       uses: notiz-dev/github-action-json-property@release
-      with: 
+      with:
         path: package_info.json
         prop_path: package_version
     - name: Get package name

--- a/workflow-templates/dev-grpc-services-pypi-publish.yml
+++ b/workflow-templates/dev-grpc-services-pypi-publish.yml
@@ -38,10 +38,10 @@ jobs:
         key: 'package_version'
         value: ${{ steps.release_ver.outputs.value }}
 # Build and publish
-    - name: Set up Python 3.7
+    - name: Set up Python 8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Create output folder
       run: mkdir -p src/gen/main/python/${{steps.pack_name.outputs.prop}}
     - name: Run codegen

--- a/workflow-templates/dev-grpc-services-pypi-publish.yml
+++ b/workflow-templates/dev-grpc-services-pypi-publish.yml
@@ -38,7 +38,7 @@ jobs:
         key: 'package_version'
         value: ${{ steps.release_ver.outputs.value }}
 # Build and publish
-    - name: Set up Python 8
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
         python-version: 3.8

--- a/workflow-templates/dev-pypi-publish.yaml
+++ b/workflow-templates/dev-pypi-publish.yaml
@@ -31,10 +31,10 @@ jobs:
         key: 'package_version'
         value: ${{ steps.release_ver.outputs.value }}
 # Build and publish
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Build package
       run: |
         pip install -r requirements.txt

--- a/workflow-templates/dev-pypi-publish.yaml
+++ b/workflow-templates/dev-pypi-publish.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
   build-n-publish:
     name: Dev build and Python distributions to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 # Prepare custom build version
     - name: Get package version
       id: pack_ver
       uses: notiz-dev/github-action-json-property@release
-      with: 
+      with:
         path: package_info.json
         prop_path: package_version
     - name: Build custom package version

--- a/workflow-templates/docker-publish-js.yml
+++ b/workflow-templates/docker-publish-js.yml
@@ -5,11 +5,11 @@ on:
     branches:
     - master
     # paths:
-    # - package.json  
+    # - package.json
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Docker Buildx
@@ -24,7 +24,7 @@ jobs:
     - name: Get package version
       id: version
       uses: notiz-dev/github-action-json-property@release
-      with: 
+      with:
         path: package.json
         prop_path: version
     - name: Build and push

--- a/workflow-templates/docker-publish.yml
+++ b/workflow-templates/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Docker Buildx

--- a/workflow-templates/grpc-services-pypi-publish.yml
+++ b/workflow-templates/grpc-services-pypi-publish.yml
@@ -10,13 +10,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and Python distributions to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Get package version
       id: version
       uses: notiz-dev/github-action-json-property@release
-      with: 
+      with:
         path: package_info.json
         prop_path: package_name
     - name: Set up Python 3.7

--- a/workflow-templates/grpc-services-pypi-publish.yml
+++ b/workflow-templates/grpc-services-pypi-publish.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         path: package_info.json
         prop_path: package_name
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Run codegen
       uses: docker://ghcr.io/th2-net/th2-python-service-generator:1.1.1
       with:

--- a/workflow-templates/license-compliance.yml
+++ b/workflow-templates/license-compliance.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   LicenseFinder:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 # Python setup
@@ -17,7 +17,7 @@ jobs:
         pip install pip==20.0.2
         echo "Python version: $(python -c "import sys; print(sys.version)")"
         echo "Pip version: $(pip3 -V)"
-# Node JS setup 
+# Node JS setup
     - uses: actions/setup-node@v2
       with:
         node-version: '12'

--- a/workflow-templates/pypi-publish.yaml
+++ b/workflow-templates/pypi-publish.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and Python distributions to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/workflow-templates/pypi-publish.yaml
+++ b/workflow-templates/pypi-publish.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Build package
       run: |
         pip install -r requirements.txt


### PR DESCRIPTION
GitHub reports an error when attempting to use `ubuntu-20.04` to increase awareness of runner removal. See [this issue]( https://github.com/actions/runner-images/issues/11101) for details

> Ubuntu 20.04 LTS runner will be removed on 2025-04-01

Update default values to `ubuntu-latest`