### PR TITLE
Skip trivy scan when workflow is triggered by dependabot

### DIFF
--- a/.github/workflows/trivy-scan-github.yml
+++ b/.github/workflows/trivy-scan-github.yml
@@ -1,4 +1,4 @@
-name: Trivy scan Docker image for vulnerable dependencies and publish results to secutity tab
+name: Trivy scan Docker image for vulnerable dependencies and publish results to security tab
 
 on:
   workflow_call:
@@ -30,6 +30,8 @@ on:
 jobs:
   trivy-scan-job:
     runs-on: ubuntu-latest
+    # dependabot doesn't publish artifacts than docker image can't be verified by trivy
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Show scanning target
         run: echo ${{ inputs.image-path }}
@@ -45,7 +47,6 @@ jobs:
           vuln-type: ${{ inputs.target }}
           timeout: 20m0s
       - name: Upload Trivy scan results to GitHub Security tab
-        if: github.actor != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
```
2025-03-03T21:29:17Z	FATAL	Fatal error	image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: unable to find the specified image "ghcr.io/th2-net/th2-cradle-admin-tool:1.12.0-dependabot_gradle_mockito-5.16.0-13640674682-9b8f487" in ["docker" "containerd" "podman" "remote"]: 4 errors occurred:
	* docker error: unable to inspect the image (ghcr.io/th2-net/th2-cradle-admin-tool:1.12.0-dependabot_gradle_mockito-5.16.0-13640674682-9b8f487): Error response from daemon: No such image: ghcr.io/th2-net/th2-cradle-admin-tool:1.12.0-dependabot_gradle_mockito-5.16.0-13640674682-9b8f487
	* containerd error: failed to initialize a containerd client: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
	* podman error: unable to initialize Podman client: no podman socket found: stat /run/user/1001/podman/podman.sock: no such file or directory
	* remote error: GET https://ghcr.io/v2/th2-net/th2-cradle-admin-tool/manifests/1.12.0-dependabot_gradle_mockito-5.16.0-13640674682-9b8f487: MANIFEST_UNKNOWN: manifest unknown
```
https://github.com/th2-net/th2-cradle-admin-tool/actions/runs/13640674682/job/38129939376?pr=38