### PR TITLE
[TH2-5279] Use Java 21 as a default java for workflow execution

### DIFF
--- a/.github/workflows/compaund-java-docker-push.yml
+++ b/.github/workflows/compaund-java-docker-push.yml
@@ -36,7 +36,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/compaund-java-multi-project-build.yml
+++ b/.github/workflows/compaund-java-multi-project-build.yml
@@ -15,7 +15,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/compaund-java-sonatype-push.yml
+++ b/.github/workflows/compaund-java-sonatype-push.yml
@@ -16,7 +16,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/compaund-python-grpc-pypi-publication.yml
+++ b/.github/workflows/compaund-python-grpc-pypi-publication.yml
@@ -16,7 +16,7 @@ on:
       java-version:
         required: false
         type: string
-        default: '11'
+        default: '21'
       java-vendor:
         required: false
         type: string

--- a/.github/workflows/compound-java-check.yml
+++ b/.github/workflows/compound-java-check.yml
@@ -13,7 +13,7 @@ on:
       java-version:
         required: false
         type: string
-        default: '11'
+        default: '21'
       java-vendor:
         required: false
         type: string

--- a/.github/workflows/compound-java-dev.yml
+++ b/.github/workflows/compound-java-dev.yml
@@ -21,7 +21,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/compound-java-scan.yml
+++ b/.github/workflows/compound-java-scan.yml
@@ -10,7 +10,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string
@@ -41,7 +41,7 @@ on:
       cisa-password:
         required: false
         description: 'Cybersecurity and Infrastructure Security Agency password'
-        
+
 jobs:
   prebuild-job:
     name: Prebuild Job

--- a/.github/workflows/compound-java.yml
+++ b/.github/workflows/compound-java.yml
@@ -22,7 +22,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/japi-compliance-checker.yml
+++ b/.github/workflows/japi-compliance-checker.yml
@@ -10,7 +10,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/java-integration-test.yml
+++ b/.github/workflows/java-integration-test.yml
@@ -6,7 +6,7 @@ on:
       java-version:
         required: false
         type: string
-        default: '11'
+        default: '21'
       java-vendor:
         required: false
         type: string

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -14,7 +14,7 @@ on:
       java-version:
         required: false
         type: string
-        default: '11'
+        default: '21'
       java-vendor:
         required: false
         type: string

--- a/.github/workflows/matrix-java-docker-dev.yml
+++ b/.github/workflows/matrix-java-docker-dev.yml
@@ -22,7 +22,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/matrix-java-docker.yml
+++ b/.github/workflows/matrix-java-docker.yml
@@ -26,7 +26,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string

--- a/.github/workflows/owasp-gradle-scan.yml
+++ b/.github/workflows/owasp-gradle-scan.yml
@@ -17,7 +17,7 @@ on:
       javaVersion:
         required: false
         type: string
-        default: '11'
+        default: '21'
       javaVendor:
         required: false
         type: string
@@ -66,15 +66,15 @@ jobs:
       - name: Run OWASP project scanning (NVD API key with CISA URL)
         # continue-on-error: true
         if: ${{ env.CISA_DOMAIN != '' }}
-        run: > 
-          ./gradlew dependencyCheckAggregate --info 
-          -PnvdApiKey=${{ secrets.nvd-api-key }} 
-          -PnvdDatafeedUrl=https://${{ secrets.cisa-domain }} 
-          -PnvdDatafeedUser=${{ secrets.cisa-user }} 
-          -PnvdDatafeedPassword=${{ secrets.cisa-password }} 
-          -PanalyzersKnownExploitedURL=https://${{ secrets.cisa-domain }}/sites/default/files/feeds/known_exploited_vulnerabilities.json 
-          -PanalyzersKnownExploitedUser=${{ secrets.cisa-user }} 
-          -PanalyzersKnownExploitedPassword=${{ secrets.cisa-password }} 
+        run: >
+          ./gradlew dependencyCheckAggregate --info
+          -PnvdApiKey=${{ secrets.nvd-api-key }}
+          -PnvdDatafeedUrl=https://${{ secrets.cisa-domain }}
+          -PnvdDatafeedUser=${{ secrets.cisa-user }}
+          -PnvdDatafeedPassword=${{ secrets.cisa-password }}
+          -PanalyzersKnownExploitedURL=https://${{ secrets.cisa-domain }}/sites/default/files/feeds/known_exploited_vulnerabilities.json
+          -PanalyzersKnownExploitedUser=${{ secrets.cisa-user }}
+          -PanalyzersKnownExploitedPassword=${{ secrets.cisa-password }}
       - name: Upload OWASP scan results to GitHub Security tab
         # dependabot does not have write access to publish scanning results (in any case we don't want that from temporal branches)
         if: (success() || failure()) && github.actor != 'dependabot[bot]'

--- a/workflow-templates/dev-java-publish-sonatype.yml
+++ b/workflow-templates/dev-java-publish-sonatype.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Show custom release version
         run: echo ${{ steps.release_ver.outputs.value }}
 # Build and publish package
-      - name: Set up JDK 11
+      - name: Set up JDK '21'
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '21'
       - name: Build with Gradle
         run: ./gradlew --info clean build publish
         env:

--- a/workflow-templates/java-publish-sonatype.yml
+++ b/workflow-templates/java-publish-sonatype.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK '21'
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '21'
       - name: Build with Gradle
         run: ./gradlew --info clean build publish closeAndReleaseSonatypeStagingRepository
         env:


### PR DESCRIPTION
The Java 11 reached its end of support some time ago. It is time to move forward and use newer java. The latest LTS is 21 at the moment. We will use it