### PR TITLE
Replace '/' char to '_' in branch name for building custom version in java multi-project

### DIFF
--- a/.github/workflows/compaund-java-multi-project-build.yml
+++ b/.github/workflows/compaund-java-multi-project-build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Get branch name
         if: ${{ !inputs.release }}
         id: branch
-        run: echo "branch_name=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        run: echo "branch_name=$(echo "${GITHUB_REF#refs/*/}" | sed 's#/#_#g')" >> $GITHUB_OUTPUT
       - name: Get SHA of the commit
         if: ${{ !inputs.release }}
         id: sha


### PR DESCRIPTION
Previous behavior affects build:
https://github.com/th2-net/th2-read-db/actions/runs/13894094851/job/38870920661?pr=49 