### PR TITLE
Added license for attr:25.4+ and MarkupSafe:3+ python libraries

### DIFF
--- a/license-compliance/gradle-license-report/allowed-licenses.json
+++ b/license-compliance/gradle-license-report/allowed-licenses.json
@@ -363,7 +363,7 @@
     {
       "moduleName": "MarkupSafe",
       "moduleVersion": "^3\\.\\d+\\.\\d+$",
-      "mvnRepositoryLicense": "MIT"
+      "mvnRepositoryLicense": "BSD-3-Clause"
     },
     {
       "moduleName": "click",

--- a/license-compliance/gradle-license-report/allowed-licenses.json
+++ b/license-compliance/gradle-license-report/allowed-licenses.json
@@ -357,10 +357,15 @@
     },
     {
       "moduleName": "attrs",
-      "moduleVersion": "^25\\.[1-3]\\.0$",
+      "moduleVersion": "^25\\.[1-4]\\.\\d+$",
       "mvnRepositoryLicense": "MIT"
     },
-        {
+    {
+      "moduleName": "MarkupSafe",
+      "moduleVersion": "^3\\.\\d+\\.\\d+$",
+      "mvnRepositoryLicense": "MIT"
+    },
+    {
       "moduleName": "click",
       "moduleVersion": "^8\\.2\\.1$",
       "mvnRepositoryLicense": "BSD-3-Clause"


### PR DESCRIPTION
This change solves license check failure https://github.com/th2-net/th2-json-stream-provider-py/actions/runs/18297475241/job/52098678177?pr=25
```text
--------------------------------------
2025-10-06 23:38:27: Line = "MarkupSafe","3.0.3","UNKNOWN"
2025-10-06 23:38:27: Result = ***FAILED***
--------------------------------------
2025-10-06 23:38:28: Line = "attrs","25.4.0","UNKNOWN"
2025-10-06 23:38:28: Result = ***FAILED***
--------------------------------------
```