### PR TITLE
Added licenses set for numpy 2.4+

### DIFF
--- a/license-compliance/gradle-license-report/allowed-licenses.json
+++ b/license-compliance/gradle-license-report/allowed-licenses.json
@@ -563,6 +563,9 @@
       "moduleLicense": "^BSD-3-Clause OR Apache 2\\.0$"
     },
     {
+      "moduleLicense": "^BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1\\.0$"
+    },
+    {
       "moduleLicense": "^BSD-2-Clause OR Apache-2\\.0$"
     },
     {


### PR DESCRIPTION
This change is required for PR https://github.com/th2-net/th2-data-services-utils/pull/25
```
--------------------------------------
2026-01-06 03:30:43: Line = "numpy","2.4.0","BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0"
2026-01-06 03:30:43: Result = ***FAILED***
--------------------------------------
```